### PR TITLE
Fix network intersection logic and remove unsupported range usage

### DIFF
--- a/tasks/vsphere_30_get_cluster_resources.yml
+++ b/tasks/vsphere_30_get_cluster_resources.yml
@@ -69,16 +69,14 @@
     host_networks: ['none']
   when: host_networks | length == 0
 
-- name: Initialize networks with the first host's networks
+- name: Initialize networks with first host entry
   set_fact:
-    networks: "{{ host_networks | first }}"
+    networks: "{{ host_networks | first | default([]) }}"
 
-- name: Find common networks across all hosts
+- name: Intersect remaining host networks
   set_fact:
-    networks: "{{ networks | intersect(host_networks[item]) }}"
-  loop: "{{ range(1, host_networks | length) }}"
-  loop_control:
-    index_var: item
+    networks: "{{ networks | intersect(item) }}"
+  loop: "{{ host_networks[1:] }}"
 
 - name: Debug - Print networks
   debug:


### PR DESCRIPTION
## Fix network intersection logic

### Problem
The previous implementation used `range()` and index-based iteration:

- breaks due to unsupported type (`range`)
- relies on imperative looping
- harder to read and debug

### Solution
Refactored to a data-driven approach:

- initialize with first element
- iteratively intersect remaining entries
- removed index-based access

### Benefits
- avoids unsupported `range` type
- improves readability and maintainability
- handles edge cases (empty list) safely
- aligns with Ansible best practices